### PR TITLE
Manage secrets via 1Password CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Rendered config — generated from config.h.tpl via `./render-config.sh`.
+# Contains plaintext secrets; never commit.
+code/Gateway/*/config.h
+
+# Flash dumps — contain plaintext secrets recovered from device.
+*_dump.bin
+
+# OS / IDE
+.DS_Store
+.vscode/
+.idea/

--- a/code/Gateway/ESP1/config.h.tpl
+++ b/code/Gateway/ESP1/config.h.tpl
@@ -1,17 +1,21 @@
+// Template — rendered to config.h by `./render-config.sh` (uses 1Password CLI).
+// Secret values are referenced via op:// URIs; non-secret tunables stay inline.
+// Never commit the rendered config.h (it contains plaintext secrets).
+
 /////////////////////////// LoRa/ESPNow Gateway Key ///////////////////////////
 
-#define GATEWAY_KEY "xy" // Keep it small
+#define GATEWAY_KEY "{{ op://CapiBridge/config/gateway_key }}" // Keep it small
 
 ///////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////// WIFI / MQTT ////////////////////////////////////
 
-#define WIFI_SSID "your_wifi_ssid"
-#define WIFI_PASSWORD "your_wifi_passwd"
-#define MQTT_USERNAME "your_mqtt_user"
-#define MQTT_PASSWORD "your_mqtt_passwd"
-#define MQTT_SERVER "your_mqtt_broker_address"
-#define MQTT_PORT 1883
+#define WIFI_SSID "{{ op://CapiBridge/config/wifi_ssid }}"
+#define WIFI_PASSWORD "{{ op://CapiBridge/config/wifi_password }}"
+#define MQTT_USERNAME "{{ op://CapiBridge/config/mqtt_username }}"
+#define MQTT_PASSWORD "{{ op://CapiBridge/config/mqtt_password }}"
+#define MQTT_SERVER "{{ op://CapiBridge/config/mqtt_server }}"
+#define MQTT_PORT {{ op://CapiBridge/config/mqtt_port }}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/code/Gateway/ESP1/config.h.tpl
+++ b/code/Gateway/ESP1/config.h.tpl
@@ -1,5 +1,5 @@
 // Template — rendered to config.h by `./render-config.sh` (uses 1Password CLI).
-// Secret values are referenced via op:// URIs; non-secret tunables stay inline.
+// Secret values reference 1Password items; non-secret tunables stay inline.
 // Never commit the rendered config.h (it contains plaintext secrets).
 
 /////////////////////////// LoRa/ESPNow Gateway Key ///////////////////////////

--- a/render-config.sh
+++ b/render-config.sh
@@ -14,8 +14,7 @@ if ! command -v op >/dev/null 2>&1; then
 fi
 
 if ! op whoami >/dev/null 2>&1; then
-  echo "error: not signed in to 1Password. run: eval \$(op signin)" >&2
-  exit 1
+  eval "$(op signin)"
 fi
 
 if [[ ! -f "$TPL" ]]; then

--- a/render-config.sh
+++ b/render-config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Render code/Gateway/ESP1/config.h from config.h.tpl using 1Password CLI.
+# Run this before compiling/flashing the sketch from Arduino IDE.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TPL="$REPO_ROOT/code/Gateway/ESP1/config.h.tpl"
+OUT="$REPO_ROOT/code/Gateway/ESP1/config.h"
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "error: 1Password CLI ('op') not found. install with: brew install 1password-cli" >&2
+  exit 1
+fi
+
+if ! op whoami >/dev/null 2>&1; then
+  echo "error: not signed in to 1Password. run: eval \$(op signin)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TPL" ]]; then
+  echo "error: template not found at $TPL" >&2
+  exit 1
+fi
+
+echo "rendering $OUT from $(basename "$TPL")..."
+op inject -i "$TPL" -o "$OUT" --force
+echo "done. config.h is gitignored; do not commit."


### PR DESCRIPTION
## Summary
- Move WiFi / MQTT / gateway-key secrets out of in-tree `config.h` and into 1Password references rendered at build time
- Commit `config.h.tpl` with `op://CapiBridge/config/<field>` placeholders; `config.h` itself is now gitignored
- Add `render-config.sh` wrapper that signs in to 1Password if needed, then runs `op inject` to produce the actual `config.h`
- Ignore `*_dump.bin` so flash dumps stay local

## Test plan
- [x] `./render-config.sh` produces `config.h` with real values populated from 1Password
- [x] Sketch compiles cleanly in Arduino IDE
- [x] Device flashes and runs against rendered config
- [x] `git status` confirms `config.h` no longer tracked; only template + script committed